### PR TITLE
Update Trim Galore! Version

### DIFF
--- a/envs/quality_check.yml
+++ b/envs/quality_check.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - fastqc=0.11.8
   - multiqc=1.5a
-  - trim-galore=0.5
+  - trim-galore=0.6.5


### PR DESCRIPTION
Update Trim Galore! version from 0.5 to 0.6.5,  as recommended in #https://github.com/FelixKrueger/TrimGalore/issues/68#issuecomment-548541428

Version 0.5 currently exits with exit signal "512"